### PR TITLE
fw_printenv: update fw_env.c to the version of nizynq/21.0/v2017.03

### DIFF
--- a/tools/env/fw_env.config
+++ b/tools/env/fw_env.config
@@ -1,7 +1,7 @@
-# Configuration file for fw_(printenv/saveenv) utility.
+# Configuration file for fw_(printenv/setenv) utility.
 # Up to two entries are valid, in this case the redundant
 # environment sector is assumed present.
-# Notice, that the "Number of sectors" is ignored on NOR and SPI-dataflash.
+# Notice, that the "Number of sectors" is not required on NOR and SPI-dataflash.
 # Futhermore, if the Flash sector size is ommitted, this value is assumed to
 # be the same as the Environment size, which is valid for NOR and SPI-dataflash
 
@@ -17,3 +17,7 @@
 
 # NAND example
 #/dev/mtd0		0x4000		0x4000		0x20000			2
+
+# Block device example
+#/dev/mmcblk0		0xc0000		0x20000
+

--- a/tools/env/fw_env.h
+++ b/tools/env/fw_env.h
@@ -2,23 +2,7 @@
  * (C) Copyright 2002-2008
  * Wolfgang Denk, DENX Software Engineering, wd@denx.de.
  *
- * See file CREDITS for list of people who contributed to this
- * project.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 2 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
- * MA 02111-1307 USA
+ * SPDX-License-Identifier:	GPL-2.0+
  */
 
 /* Pull in the current config to define the default environment */

--- a/tools/env/fw_env_main.c
+++ b/tools/env/fw_env_main.c
@@ -2,23 +2,7 @@
  * (C) Copyright 2000-2008
  * Wolfgang Denk, DENX Software Engineering, wd@denx.de.
  *
- * See file CREDITS for list of people who contributed to this
- * project.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 2 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
- * MA 02111-1307 USA
+ * SPDX-License-Identifier:	GPL-2.0+
  */
 
 /*
@@ -94,7 +78,7 @@ int main(int argc, char *argv[])
 	int lockfd = -1;
 	int retval = EXIT_SUCCESS;
 
-	lockfd = open(lockname, O_WRONLY | O_CREAT | O_TRUNC);
+	lockfd = open(lockname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (-1 == lockfd) {
 		fprintf(stderr, "Error opening lock file %s\n", lockname);
 		return EXIT_FAILURE;
@@ -154,3 +138,4 @@ exit:
 	close(lockfd);
 	return retval;
 }
+


### PR DESCRIPTION
According to NIOE's bitbake recipe, fw_printenv utility is taken from
github's u-boot branch, which is currently at nizynq/15.0/v2012.10. This
version of fw_printenv uses a fixed 16 characters array when running
get_config(), which did not work for artemis because artemis's design uses
a longer path name for its u-boot environmental variable
(/boot/uboot/uboot.env) which exceeds 16 characters.

The fw_printenv in the v2017.03 branch has an updated version fw_printenv
from the upstream branch which allocates memory dynamically that allows any
length of config path to work. By fast-forwarding fw_env.c to this version,
we can allow fw_printenv to work on artemis.

This commit updates fw_env.c to the version of nizynq/21.0/v2017.03 branch
in the git.natinst.com repository.

@ni/rtos 

Signed-off-by: wkoe <wilson.koe@ni.com>